### PR TITLE
rm reloader flags

### DIFF
--- a/base/prometheus.yaml
+++ b/base/prometheus.yaml
@@ -110,7 +110,6 @@ spec:
         - --reloader.config-file=/etc/prometheus/prometheus.yaml.tmpl
         - --reloader.config-envsubst-file=/etc/prometheus-shared/prometheus.yaml
         - --tsdb.path=/prometheus/data
-        - --reloader.rule-dir=/etc/alerts/..data/
         - --objstore.config-file=/etc/thanos/config.yaml
         ports:
         - name: http


### PR DESCRIPTION
Since the configMaps are handled by kustomize's generators, we don't
need to watch and reload on change, since a change will update the spec
and redeploy