### PR TITLE
thanos v0.10.0-rc.0 and prometheus v2.15.2

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -11,7 +11,7 @@ resources:
 images:
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.9.0
+    newTag: v0.10.0-rc.0
   - name: prometheus
     newName: prom/prometheus
-    newTag: v2.15.1
+    newTag: v2.15.2


### PR DESCRIPTION
Thanos `v0.10.0-rc.0` allows the use of the environment variable `AWS_CONTAINER_CREDENTIALS_FULL_URI` to fetch credentials from a local http endpoint (among other things).