### PR TITLE
Add explicit service accounts for all thanos components

### DIFF
--- a/base/thanos-compact.yaml
+++ b/base/thanos-compact.yaml
@@ -18,6 +18,11 @@ spec:
     app: thanos-compact
   sessionAffinity: None
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: thanos-compact
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -36,6 +41,7 @@ spec:
       name: thanos-compact
     spec:
       terminationGracePeriodSeconds: 1200
+      serviceAccountName: thanos-compact
       containers:
       - name: thanos-compact
         image: thanos

--- a/base/thanos-query.yaml
+++ b/base/thanos-query.yaml
@@ -22,6 +22,11 @@ spec:
     app: thanos-query
   sessionAffinity: None
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: thanos-query
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -38,6 +43,7 @@ spec:
       labels:
         app: thanos-query
     spec:
+      serviceAccountName: thanos-query
       containers:
       - name: thanos-query
         image: thanos

--- a/base/thanos-rule.yaml
+++ b/base/thanos-rule.yaml
@@ -22,6 +22,11 @@ spec:
     app: thanos-rule
   sessionAffinity: None
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: thanos-rule
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -38,6 +43,7 @@ spec:
       labels:
         app: thanos-rule
     spec:
+      serviceAccountName: thanos-rule
       containers:
       - name: thanos-rule
         image: thanos

--- a/base/thanos-store.yaml
+++ b/base/thanos-store.yaml
@@ -17,6 +17,11 @@ spec:
     app: thanos-store
   sessionAffinity: None
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: thanos-store
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -35,6 +40,7 @@ spec:
       labels:
         app: thanos-store
     spec:
+      serviceAccountName: thanos-store
       containers:
       - name: thanos-store
         image: thanos


### PR DESCRIPTION
That way it can play well with setups that delegate permissions based on
service account names, like vault.