### PR TITLE
Add kustomize config for IngressRoute

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -11,3 +11,5 @@ images:
   - name: thanos
     newName: quay.io/thanos/thanos
     newTag: v0.11.0
+configurations:
+- thanos-prometheus/kustomizeconfig/ingressroute.yaml

--- a/base/thanos-prometheus/kustomization.yaml
+++ b/base/thanos-prometheus/kustomization.yaml
@@ -13,3 +13,5 @@ images:
   - name: prometheus
     newName: prom/prometheus
     newTag: v2.17.1
+configurations:
+- kustomizeconfig/ingressroute.yaml

--- a/base/thanos-prometheus/kustomizeconfig/ingressroute.yaml
+++ b/base/thanos-prometheus/kustomizeconfig/ingressroute.yaml
@@ -1,0 +1,7 @@
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - path: spec/routes/services/name
+    version: v1alpha1
+    kind: IngressRoute


### PR DESCRIPTION
This allows kustomize to properly handle the Service names referenced in
traefik's IngressRoute spec.