### PR TITLE
Experimental flag removed, enabled by default

### DIFF
--- a/base/thanos-store/thanos-store.yaml
+++ b/base/thanos-store/thanos-store.yaml
@@ -51,7 +51,6 @@ spec:
         - --objstore.config-file=/etc/thanos/config.yaml
         - --index-cache-size=4GB
         - --chunk-pool-size=6GB
-        - --experimental.enable-index-cache-postings-compression
         ports:
         - name: http
           containerPort: 10902


### PR DESCRIPTION
https://thanos.io/tip/thanos/changelog.md/#v0170httpsgithubcomthanos-iothanosreleasestagv0170---20201118
