### PR TITLE
Set retention to 1y

### DIFF
--- a/base/thanos-compact/thanos-compact.yaml
+++ b/base/thanos-compact/thanos-compact.yaml
@@ -52,6 +52,9 @@ spec:
         - --wait
         - --consistency-delay=30m
         - --objstore.config-file=/etc/thanos/config.yaml
+        - --retention.resolution-raw=1y
+        - --retention.resolution-5m=1y
+        - --retention.resolution-1h=1y
         ports:
         - name: http
           containerPort: 10902


### PR DESCRIPTION
Prevent object storage usage from growing limitlessly but still default to a long default.