### PR TITLE
Update Thanos to 0.24 RC version

### DIFF
--- a/base/prometheus/kustomization.yaml
+++ b/base/prometheus/kustomization.yaml
@@ -10,4 +10,4 @@ images:
     newTag: v2.30.3
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.23.1
+    newTag: v0.24.0-rc.2

--- a/base/thanos-compact/kustomization.yaml
+++ b/base/thanos-compact/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.23.1
+    newTag: v0.24.0-rc.2

--- a/base/thanos-query/kustomization.yaml
+++ b/base/thanos-query/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.23.1
+    newTag: v0.24.0-rc.2

--- a/base/thanos-rule/kustomization.yaml
+++ b/base/thanos-rule/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.23.1
+    newTag: v0.24.0-rc.2

--- a/base/thanos-store/kustomization.yaml
+++ b/base/thanos-store/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.23.1
+    newTag: v0.24.0-rc.2


### PR DESCRIPTION
Mainly to address https://github.com/thanos-io/thanos/pull/4795 - which
is happening frequently in prod-aws/sys-mon
