### PR TITLE
Update Thanos and Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,6 @@
 This repository provides [Kustomize][1] base to deploy [Prometheus][2] +
 [Thanos][3] and example overlays for general deployment in either AWS or GCP.
 
-Table of Contents
-=================
-
-   * [Thanos Manifests](#thanos-manifests)
-   * [Table of Contents](#table-of-contents)
-      * [Usage](#usage)
-         * [Additional Components](#additional-components)
-         * [AWS configuration](#aws-configuration)
-         * [GCP configuration](#gcp-configuration)
-      * [Requires](#requires)
-      * [Migration to v0.4.0 notes](#migration-to-v040-notes)
-
-Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc)
-
 ## Usage
 
 To use the base, reference the remote in you `kustomization.yaml`
@@ -24,8 +10,8 @@ To use the base, reference the remote in you `kustomization.yaml`
 ```
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-  - github.com/utilitywarehouse/thanos-manifests/base?ref=v1.3.1
+resources:
+  - github.com/utilitywarehouse/thanos-manifests/base?ref=master
 ```
 
 You then MUST patch the following resources:
@@ -61,10 +47,10 @@ configuration. You can reference the more specific bases:
 ```
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-  - github.com/utilitywarehouse/thanos-manifests/base/prometheus?ref=v1.3.1
-  - github.com/utilitywarehouse/thanos-manifests/base/thanos-store?ref=v1.3.1
-  - github.com/utilitywarehouse/thanos-manifests/base/thanos-compact?ref=v1.3.1
+resources:
+  - github.com/utilitywarehouse/thanos-manifests/base/prometheus?ref=master
+  - github.com/utilitywarehouse/thanos-manifests/base/thanos-store?ref=master
+  - github.com/utilitywarehouse/thanos-manifests/base/thanos-compact?ref=master
 ```
 
 Note that in this case you must still follow the configuration instructions in

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
   - ./thanos-query
   - ./thanos-rule
   - ./thanos-compact

--- a/base/prometheus/kustomization.yaml
+++ b/base/prometheus/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 images:
   - name: prometheus
     newName: prom/prometheus
-    newTag: v2.30.3
+    newTag: v2.33.4
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.24.0-rc.2
+    newTag: v0.24.0

--- a/base/prometheus/prometheus.yaml
+++ b/base/prometheus/prometheus.yaml
@@ -94,7 +94,7 @@ spec:
           image: thanos
           args:
             - sidecar
-            - --log.level=info
+            - --log.level=warn
             - --prometheus.url=http://127.0.0.1:9090
             - --reloader.config-file=/etc/prometheus/prometheus.yaml.tmpl
             - --reloader.config-envsubst-file=/etc/prometheus-shared/prometheus.yaml
@@ -124,7 +124,7 @@ spec:
               mountPath: /etc/thanos
         - name: prometheus
           args:
-            - --log.level=info
+            - --log.level=warn
             - --config.file=/etc/prometheus-shared/prometheus.yaml
             - --storage.tsdb.path=/prometheus/data
             - --storage.tsdb.retention=$(PROMETHEUS_DB_RETENTION)

--- a/base/thanos-compact/kustomization.yaml
+++ b/base/thanos-compact/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.24.0-rc.2
+    newTag: v0.24.0

--- a/base/thanos-compact/thanos-compact.yaml
+++ b/base/thanos-compact/thanos-compact.yaml
@@ -10,10 +10,10 @@ metadata:
     prometheus.io/scrape: "true"
 spec:
   ports:
-  - port: 10902
-    protocol: TCP
-    targetPort: http
-    name: http-query
+    - port: 10902
+      protocol: TCP
+      targetPort: http
+      name: http-query
   selector:
     app: thanos-compact
   sessionAffinity: None
@@ -45,57 +45,56 @@ spec:
       terminationGracePeriodSeconds: 1200
       serviceAccountName: thanos-compact
       containers:
-      - name: thanos-compact
-        image: thanos
-        args:
-        - compact
-        - --log.level=info
-        - --data-dir=/var/thanos/compact
-        - --wait
-        - --consistency-delay=30m
-        - --objstore.config-file=/etc/thanos/config.yaml
-        - --retention.resolution-raw=1y
-        - --retention.resolution-5m=1y
-        - --retention.resolution-1h=1y
-        ports:
-        - name: http
-          containerPort: 10902
-        livenessProbe:
-          httpGet:
-            path: /-/healthy
-            port: http
-            scheme: HTTP
-          periodSeconds: 90
-          successThreshold: 1
-          failureThreshold: 5
-          timeoutSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /-/ready
-            port: http
-            scheme: HTTP
-          periodSeconds: 90
-          successThreshold: 1
-          failureThreshold: 5
-          timeoutSeconds: 10
-        volumeMounts:
-        - name: data
-          mountPath: /var/thanos/compact
-        - name: thanos-storage
-          mountPath: /etc/thanos
-        resources:
-          requests:
-            cpu: 0
-            memory: 50Mi
-          limits:
-            memory: 2Gi
+        - name: thanos-compact
+          image: thanos
+          args:
+            - compact
+            - --log.level=warn
+            - --data-dir=/var/thanos/compact
+            - --wait
+            - --objstore.config-file=/etc/thanos/config.yaml
+            - --retention.resolution-raw=1y
+            - --retention.resolution-5m=1y
+            - --retention.resolution-1h=1y
+          ports:
+            - name: http
+              containerPort: 10902
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: http
+              scheme: HTTP
+            periodSeconds: 90
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http
+              scheme: HTTP
+            periodSeconds: 90
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 10
+          volumeMounts:
+            - name: data
+              mountPath: /var/thanos/compact
+            - name: thanos-storage
+              mountPath: /etc/thanos
+          resources:
+            requests:
+              cpu: 0
+              memory: 50Mi
+            limits:
+              memory: 2Gi
       volumes:
-      - name: data
-        persistentVolumeClaim:
-          claimName: thanos-compact
-      - name: thanos-storage
-        configMap:
-          name: thanos-storage
+        - name: data
+          persistentVolumeClaim:
+            claimName: thanos-compact
+        - name: thanos-storage
+          configMap:
+            name: thanos-storage
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -103,7 +102,7 @@ metadata:
   name: thanos-compact
 spec:
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
   resources:
     requests:
       storage: 100Gi

--- a/base/thanos-query/kustomization.yaml
+++ b/base/thanos-query/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.24.0-rc.2
+    newTag: v0.24.0

--- a/base/thanos-query/thanos-query.yaml
+++ b/base/thanos-query/thanos-query.yaml
@@ -10,14 +10,14 @@ metadata:
   name: thanos-query
 spec:
   ports:
-  - port: 9090
-    protocol: TCP
-    targetPort: http
-    name: http
-  - port: 10901
-    protocol: TCP
-    targetPort: grpc
-    name: grpc
+    - port: 9090
+      protocol: TCP
+      targetPort: http
+      name: http
+    - port: 10901
+      protocol: TCP
+      targetPort: grpc
+      name: grpc
   selector:
     app: thanos-query
   sessionAffinity: None
@@ -48,48 +48,47 @@ spec:
     spec:
       serviceAccountName: thanos-query
       containers:
-      - name: thanos-query
-        image: thanos
-        args:
-        - query
-        - --log.level=info
-        - --query.replica-label=replica
-        - --store.sd-files=/etc/thanos/store-sd.yaml
-        - --query.timeout=5m
-        - --store.response-timeout=15s
-        ports:
-        - name: http
-          containerPort: 10902
-        - name: grpc
-          containerPort: 10901
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /-/healthy
-            port: http
-            scheme: HTTP
-          periodSeconds: 60
-          successThreshold: 1
-          timeoutSeconds: 1
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /-/ready
-            port: http
-            scheme: HTTP
-          periodSeconds: 60
-          successThreshold: 1
-          timeoutSeconds: 1
-        resources:
-          requests:
-            cpu: 50m
-            memory: 500Mi
-          limits:
-            memory: 4000Mi
-        volumeMounts:
-        - name: config
-          mountPath: /etc/thanos
+        - name: thanos-query
+          image: thanos
+          args:
+            - query
+            - --log.level=warn
+            - --query.replica-label=replica
+            - --store.sd-files=/etc/thanos/store-sd.yaml
+            - --store.response-timeout=15s
+          ports:
+            - name: http
+              containerPort: 10902
+            - name: grpc
+              containerPort: 10901
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /-/healthy
+              port: http
+              scheme: HTTP
+            periodSeconds: 60
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /-/ready
+              port: http
+              scheme: HTTP
+            periodSeconds: 60
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            requests:
+              cpu: 50m
+              memory: 500Mi
+            limits:
+              memory: 4000Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/thanos
       volumes:
-      - name: config
-        configMap:
-          name: thanos-query
+        - name: config
+          configMap:
+            name: thanos-query

--- a/base/thanos-rule/kustomization.yaml
+++ b/base/thanos-rule/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.24.0-rc.2
+    newTag: v0.24.0

--- a/base/thanos-rule/thanos-rule.yaml
+++ b/base/thanos-rule/thanos-rule.yaml
@@ -10,14 +10,14 @@ metadata:
   name: thanos-rule
 spec:
   ports:
-  - port: 10902
-    protocol: TCP
-    targetPort: http
-    name: http-rule
-  - port: 10901
-    protocol: TCP
-    targetPort: grpc
-    name: grpc-rule
+    - port: 10902
+      protocol: TCP
+      targetPort: http
+      name: http-rule
+    - port: 10901
+      protocol: TCP
+      targetPort: grpc
+      name: grpc-rule
   selector:
     app: thanos-rule
   sessionAffinity: None
@@ -48,66 +48,66 @@ spec:
     spec:
       serviceAccountName: thanos-rule
       containers:
-      - name: thanos-rule
-        image: thanos
-        args:
-        - rule
-        - --log.level=info
-        - --data-dir=/var/thanos/data/
-        - --rule-file=/var/thanos/rules/*.yaml
-        - --alertmanagers.url=$(ALERTMANAGER_URL)
-        - --eval-interval=30s
-        - --alert.query-url=$(THANOS_QUERY_URL)
-        - --query.sd-files=/etc/thanos/query-sd.yaml
-        env:
-        - name: ALERTMANAGER_URL
-          value: "dns+http://alertmanager.base-namespace"
-        # external URL for rendering inside alerts
-        - name: THANOS_QUERY_URL
-          value: "https://thanos-query.base.example.com"
-        ports:
-        - name: http
-          containerPort: 10902
-        - name: grpc
-          containerPort: 10901
-        livenessProbe:
-          httpGet:
-            path: /-/healthy
-            port: http
-            scheme: HTTP
-          periodSeconds: 15
-          successThreshold: 1
-          failureThreshold: 5
-          timeoutSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /-/ready
-            port: http
-            scheme: HTTP
-          periodSeconds: 15
-          successThreshold: 1
-          timeoutSeconds: 10
-          failureThreshold: 5
-        volumeMounts:
-        - name: data
-          mountPath: /var/thanos/data
-        - name: rules
-          mountPath: /var/thanos/rules
-        - name: config
-          mountPath: /etc/thanos
-        resources:
-          requests:
-            cpu: 50m
-            memory: 200Mi
-          limits:
-            memory: 500Mi
+        - name: thanos-rule
+          image: thanos
+          args:
+            - rule
+            - --log.level=warn
+            - --data-dir=/var/thanos/data/
+            - --rule-file=/var/thanos/rules/*.yaml
+            - --alertmanagers.url=$(ALERTMANAGER_URL)
+            - --eval-interval=30s
+            - --alert.query-url=$(THANOS_QUERY_URL)
+            - --query.sd-files=/etc/thanos/query-sd.yaml
+          env:
+            - name: ALERTMANAGER_URL
+              value: "dns+http://alertmanager.base-namespace"
+            # external URL for rendering inside alerts
+            - name: THANOS_QUERY_URL
+              value: "https://thanos-query.base.example.com"
+          ports:
+            - name: http
+              containerPort: 10902
+            - name: grpc
+              containerPort: 10901
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: http
+              scheme: HTTP
+            periodSeconds: 15
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http
+              scheme: HTTP
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 10
+            failureThreshold: 5
+          volumeMounts:
+            - name: data
+              mountPath: /var/thanos/data
+            - name: rules
+              mountPath: /var/thanos/rules
+            - name: config
+              mountPath: /etc/thanos
+          resources:
+            requests:
+              cpu: 50m
+              memory: 200Mi
+            limits:
+              memory: 500Mi
       volumes:
-      - name: data
-        emptyDir: {}
-      - name: rules
-        configMap:
-          defaultMode: 420
-          name: alerts
-      - name: config
-        configMap:
-          name: thanos-rule
+        - name: data
+          emptyDir: {}
+        - name: rules
+          configMap:
+            defaultMode: 420
+            name: alerts
+        - name: config
+          configMap:
+            name: thanos-rule

--- a/base/thanos-store/kustomization.yaml
+++ b/base/thanos-store/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.24.0-rc.2
+    newTag: v0.24.0

--- a/base/thanos-store/thanos-store.yaml
+++ b/base/thanos-store/thanos-store.yaml
@@ -49,11 +49,9 @@ spec:
           image: thanos
           args:
             - store
-            - --log.level=info
+            - --log.level=warn
             - --data-dir=/var/thanos/store
             - --objstore.config-file=/etc/thanos/config.yaml
-            - --index-cache-size=4GB
-            - --chunk-pool-size=6GB
           ports:
             - name: http
               containerPort: 10902


### PR DESCRIPTION
- Update Thanos to non-RC v0.24.0
- Update Prometheus to v2.33.4
- Default all components to WARN level logging
- Use default "--chunk-pool-size" value for thanos-store
- Use default "--index-cache-size" value for thanos-store
- Use defualt "--consistency-delay" (30m) for thanos-compact
- Use default "--query.timeout" (2m) for thanos-query
