### PR TITLE
Add thanos-receive sub-base

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository provides [Kustomize][1] base to deploy [Prometheus][2] +
 
 ## Usage
 
-To use the base, reference the remote in you `kustomization.yaml`
+To use the base, reference the remote in your `kustomization.yaml`
 
 ```
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -55,6 +55,15 @@ resources:
 
 Note that in this case you must still follow the configuration instructions in
 the previous section, ignoring any parts for `thanos-rule` and `thanos-query`.
+
+#### Enabling remote-write with thanos-receive
+
+The other optional component is thanos-receive, that provides a prometheus'
+remote-write endpoint.
+
+To deploy it, add the `thanos-receive` sub-base to your kustomize, and apply
+any patches that may be needed (in UW's case, the SA and STS labels to get S3
+credentials from vault)
 
 ### AWS configuration (UW specifc)
 

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
   - ./thanos-rule
   - ./thanos-compact
   - ./thanos-store
-  - ./thanos-receive
   - ./prometheus
 commonLabels:
   service: monitoring

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ./thanos-rule
   - ./thanos-compact
   - ./thanos-store
+  - ./thanos-receive
   - ./prometheus
 commonLabels:
   service: monitoring

--- a/base/thanos-receive/kustomization.yaml
+++ b/base/thanos-receive/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  service: monitoring
+resources:
+  - thanos-receive.yaml
+images:
+  - name: thanos
+    newName: quay.io/thanos/thanos
+    newTag: v0.28.0

--- a/base/thanos-receive/thanos-receive.yaml
+++ b/base/thanos-receive/thanos-receive.yaml
@@ -1,0 +1,111 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: thanos-receive
+  labels:
+    app.kubernetes.io/name: thanos-receive
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "10902"
+spec:
+  selector:
+    app.kubernetes.io/name: thanos-receive
+  clusterIP: None
+  ports:
+    - name: grpc
+      port: 10901
+      targetPort: grcp
+    - name: http
+      port: 10902
+      targetPort: http
+    - name: remote-write
+      port: 19291
+      targetPort: remote-write
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: thanos-receive
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: thanos-receive
+  labels:
+    app.kubernetes.io/name: thanos-receive
+spec:
+  replicas: 1
+  serviceName: thanos-receive
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: thanos-receive
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: thanos-receive
+    spec:
+      serviceAccountName: thanos-receive
+      containers:
+        - name: thanos-receive
+          image: thanos
+          args:
+            - receive
+            - --log.level=warn
+            - --tsdb.path=/var/thanos/receive
+            - --label=receive_replica="$(NAME)"
+            - --objstore.config-file=/etc/thanos/config.yaml
+          ports:
+            - name: http
+              containerPort: 10902
+            - name: grpc
+              containerPort: 10901
+            - name: remote-write
+              containerPort: 19291
+          env:
+            - name: NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: http
+              scheme: HTTP
+            periodSeconds: 20
+            successThreshold: 1
+            failureThreshold: 25
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http
+              scheme: HTTP
+            periodSeconds: 20
+            successThreshold: 1
+            failureThreshold: 25
+            timeoutSeconds: 10
+          volumeMounts:
+            - name: data
+              mountPath: /var/thanos/receive
+            - name: thanos-storage
+              mountPath: /etc/thanos
+          resources:
+            requests:
+              cpu: 0m
+              memory: 500Mi
+            limits:
+              memory: 4000Mi
+      volumes:
+        - name: thanos-storage
+          configMap:
+            name: thanos-storage
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 50Gi

--- a/example/aws/kustomization.yaml
+++ b/example/aws/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 bases:
   - ../../base/
 #  - github.com/utilitywarehouse/thanos-manifests/base
+
+# Optional, only required to enable remote-write
+  - ../../base/thanos-receive
+#  - github.com/utilitywarehouse/thanos-manifests/base/thanos-receive
 resources:
   - prometheus-ingress.yaml
   - thanos-query-ingress.yaml
@@ -10,6 +14,7 @@ resources:
 patchesStrategicMerge:
   - prometheus.yaml
   - thanos-compact.yaml
+  - thanos-receive.yaml # Optional, only required to enable remote-write
   - thanos-rule.yaml
   - thanos-store.yaml
 configMapGenerator:

--- a/example/aws/resources/store-sd.yaml
+++ b/example/aws/resources/store-sd.yaml
@@ -3,6 +3,8 @@
   # Prometheus sidecars for the short term metrics
   - prometheus-0.thanos-sidecar:10901
   - prometheus-1.thanos-sidecar:10901
+  # Thanos Receive store gateway for short term metrics
+  - thanos-receive:10901
   # Store gateway for long term metrics
   - thanos-store:10901
   # Thanos ruler exposes synthetic time series of the form

--- a/example/aws/thanos-receive.yaml
+++ b/example/aws/thanos-receive.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: thanos-receive
+  annotations:
+    vault.uw.systems/aws-role: "arn:aws:iam::000000000000:role/example-role"
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: thanos-receive
+spec:
+  template:
+    metadata:
+      annotations:
+        injector.tumblr.com/request: vault-sidecar-aws


### PR DESCRIPTION
Thanos-receive implements prometheus' remote-write api, so compatible clients can send blocks to it and thanos will back them up in object storage

Note that they sts only has one replica, since the remote-write API has retries built in, to tolerate updates on the receiving server. Thanos receive support HA deployments but we don't need that complexity for our current usage (receiving log based metrics from loki)