### PR TITLE
Deploy memcached with thanos-store

### DIFF
--- a/base/thanos-store/README.md
+++ b/base/thanos-store/README.md
@@ -1,0 +1,21 @@
+# Store
+## Updating Memcached
+
+Add Bitnami repo locally:
+
+```
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+```
+
+Render Memcached manifest:
+
+```
+$ helm template thanos-store bitnami/memcached -f values.yaml > memcached.yaml
+```
+
+It comes with `namespace: default`, so remove that, I don't know if there is a
+Helm native way to do it:
+
+```
+$ sd '^\s*namespace: default\n' '' memcached.yaml
+```

--- a/base/thanos-store/kustomization.yaml
+++ b/base/thanos-store/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 commonLabels:
   service: monitoring
 resources:
+  - memcached-peers-svc.yaml
+  - memcached.yaml
   - thanos-store.yaml
 images:
   - name: thanos

--- a/base/thanos-store/memcached-peers-svc.yaml
+++ b/base/thanos-store/memcached-peers-svc.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: thanos-store-memcached-peers
+  labels:
+    app.kubernetes.io/name: memcached
+    app.kubernetes.io/instance: thanos-store
+  annotations:
+spec:
+  clusterIP: None
+  sessionAffinity: None
+  ports:
+    - name: memcache
+      port: 11211
+      targetPort: memcache
+      nodePort: null
+  selector:
+    app.kubernetes.io/name: memcached
+    app.kubernetes.io/instance: thanos-store

--- a/base/thanos-store/memcached.yaml
+++ b/base/thanos-store/memcached.yaml
@@ -1,0 +1,143 @@
+---
+# Source: memcached/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: thanos-store-memcached
+  labels:
+    app.kubernetes.io/name: memcached
+    helm.sh/chart: memcached-6.3.0
+    app.kubernetes.io/instance: thanos-store
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: memcache
+      port: 11211
+      targetPort: memcache
+      nodePort: null
+  selector:
+    app.kubernetes.io/name: memcached
+    app.kubernetes.io/instance: thanos-store
+---
+# Source: memcached/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: thanos-store-memcached
+  labels:
+    app.kubernetes.io/name: memcached
+    helm.sh/chart: memcached-6.3.0
+    app.kubernetes.io/instance: thanos-store
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: memcached
+      app.kubernetes.io/instance: thanos-store
+  replicas: 2
+  podManagementPolicy: "Parallel"
+  serviceName: thanos-store-memcached
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: memcached
+        helm.sh/chart: memcached-6.3.0
+        app.kubernetes.io/instance: thanos-store
+        app.kubernetes.io/managed-by: Helm
+      annotations:
+    spec:
+      
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: memcached
+                    app.kubernetes.io/instance: thanos-store
+                namespaces:
+                  - "default"
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+      serviceAccountName: default
+      initContainers:
+      containers:
+        - name: memcached
+          image: docker.io/bitnami/memcached:1.6.17-debian-11-r15
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          args:
+            - /run.sh
+            - --memory-file=/cache-state/memory_file
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: MEMCACHED_PORT_NUMBER
+              value: "11211"
+          ports:
+            - name: memcache
+              containerPort: 11211
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            tcpSocket:
+              port: memcache
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+            tcpSocket:
+              port: memcache
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -ec
+                  - |
+                    /usr/bin/pkill -10 memcached
+                    sleep 60s
+          resources:
+            limits:
+              cpu: 2
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+          volumeMounts:
+            - name: data
+              mountPath: /cache-state
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        annotations:
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "10Gi"

--- a/base/thanos-store/thanos-store.yaml
+++ b/base/thanos-store/thanos-store.yaml
@@ -1,3 +1,4 @@
+# https://github.com/thanos-io/kube-thanos/blob/main/examples/all/manifests/thanos-store-statefulSet.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -55,7 +56,7 @@ spec:
             - |-
               --index-cache.config="config":
                 "addresses":
-                - "dnssrv+_memcache._tcp.thanos-store-memcached-peers"
+                - "dnssrv+_memcache._tcp.$(MEMCACHED_SVC)"
                 "dns_provider_update_interval": "10s"
                 "max_async_buffer_size": 10000
                 "max_async_concurrency": 20
@@ -65,6 +66,9 @@ spec:
                 "max_item_size": "1MiB"
                 "timeout": "500ms"
               "type": "memcached"
+          env:
+            - name: "MEMCACHED_SVC"
+              value: "thanos-store-memcached-peers"
           ports:
             - name: http
               containerPort: 10902

--- a/base/thanos-store/thanos-store.yaml
+++ b/base/thanos-store/thanos-store.yaml
@@ -52,6 +52,19 @@ spec:
             - --log.level=warn
             - --data-dir=/var/thanos/store
             - --objstore.config-file=/etc/thanos/config.yaml
+            - |-
+              --index-cache.config="config":
+                "addresses":
+                - "dnssrv+_memcache._tcp.thanos-store-memcached-peers"
+                "dns_provider_update_interval": "10s"
+                "max_async_buffer_size": 10000
+                "max_async_concurrency": 20
+                "max_get_multi_batch_size": 0
+                "max_get_multi_concurrency": 100
+                "max_idle_connections": 100
+                "max_item_size": "1MiB"
+                "timeout": "500ms"
+              "type": "memcached"
           ports:
             - name: http
               containerPort: 10902

--- a/base/thanos-store/values.yaml
+++ b/base/thanos-store/values.yaml
@@ -1,0 +1,9 @@
+architecture: "high-availability"
+replicaCount: 2
+persistence:
+  enabled: true
+  size: 10Gi
+resources:
+  limits:
+    cpu: 2
+    memory: 1Gi


### PR DESCRIPTION
Thanos Store is currently the highest user of S3 API, which costs alot
in terms of traffic, as well as monitoring (CloudWatch / CloudTrail).

If we cache index, it should bring these down considerably.
