### PR TITLE
Update Prometheus 2.44.0 and Thanos v0.31.0

### DIFF
--- a/base/prometheus/kustomization.yaml
+++ b/base/prometheus/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 images:
   - name: prometheus
     newName: prom/prometheus
-    newTag: v2.41.0
+    newTag: v2.44.0
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.30.1
+    newTag: v0.31.0

--- a/base/thanos-compact/kustomization.yaml
+++ b/base/thanos-compact/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.30.1
+    newTag: v0.31.0

--- a/base/thanos-query/kustomization.yaml
+++ b/base/thanos-query/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.30.1
+    newTag: v0.31.0

--- a/base/thanos-receive/kustomization.yaml
+++ b/base/thanos-receive/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.30.1
+    newTag: v0.31.0

--- a/base/thanos-rule/kustomization.yaml
+++ b/base/thanos-rule/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.30.1
+    newTag: v0.31.0

--- a/base/thanos-store/kustomization.yaml
+++ b/base/thanos-store/kustomization.yaml
@@ -11,4 +11,4 @@ patches:
 images:
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.30.1
+    newTag: v0.31.0


### PR DESCRIPTION
- https://github.com/prometheus/prometheus/releases/tag/v2.44.0
- https://github.com/thanos-io/thanos/releases/tag/v0.31.0
