### PR TITLE
Remove arbitrary low mem limit for thanos sidecar

### DIFF
--- a/base/prometheus/prometheus.yaml
+++ b/base/prometheus/prometheus.yaml
@@ -110,7 +110,7 @@ spec:
               cpu: 0m
               memory: 32Mi
             limits:
-              memory: 256Mi
+              memory: 1Gi
           volumeMounts:
             - name: prometheus
               mountPath: /prometheus


### PR DESCRIPTION
We have observed ~350Mi usage in dev-aws on start-up
