### PR TITLE
Halve prometheus retention period to 1d

### DIFF
--- a/base/prometheus/prometheus.yaml
+++ b/base/prometheus/prometheus.yaml
@@ -138,7 +138,7 @@ spec:
             - name: PROMETHEUS_URL
               value: "https://prometheus.base.example.com"
             - name: PROMETHEUS_DB_RETENTION
-              value: "2d"
+              value: "1d"
           image: prometheus
           livenessProbe:
             failureThreshold: 3


### PR DESCRIPTION
We see that prometheus gets cpu throttled even with 6 cores as limit which seems to be our scheduler limit based on the nodes we deploy. Lowering the retention period should mean much less cpu, but querying thanos-query for older metrics might get slower. thanos-sidecar pushes metrics older than 2h so we are still very well above that threshold.