### PR TITLE
Revert "Halve prometheus retention period to 1d"

### DIFF
--- a/base/prometheus/prometheus.yaml
+++ b/base/prometheus/prometheus.yaml
@@ -138,7 +138,7 @@ spec:
             - name: PROMETHEUS_URL
               value: "https://prometheus.base.example.com"
             - name: PROMETHEUS_DB_RETENTION
-              value: "1d"
+              value: "2d"
           image: prometheus
           livenessProbe:
             failureThreshold: 3


### PR DESCRIPTION
This reverts commit 23d552f0c71e7dcec0ceef6f68aadd454f1d15ae.

Let's not do a flat rule for this but start by patching the bigger prometheus instances we run downstream