### PR TITLE
Revert to last good version of thanos-query

### DIFF
--- a/base/thanos-query/kustomization.yaml
+++ b/base/thanos-query/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 images:
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.36.0
+    newTag: v0.35.1
 labels:
   - includeSelectors: true
     pairs:


### PR DESCRIPTION
Running v0.36.0 we have observed concurrent_gate_queries go to 20 which
is default max and would result in queries timing out triggering
heartbeat alerts.

Running v0.35.1 thanos_query_concurrent_gate_queries_in_flight rarely
grows above 1.
