### PR TITLE
trap signal for gracefull shutdown

### DIFF
--- a/components/rule-watcher/rule-watcher
+++ b/components/rule-watcher/rule-watcher
@@ -2,6 +2,8 @@
 
 apk add --no-cache  curl gettext inotify-tools;
 
+trap 'echo TERM signal received exiting...; exit' SIGINT SIGTERM
+
 substituteENV() {
     echo "substituting the values of environment variables in rules..."
     find "$TEMPLATED_RULES_PATH" -type f | while read -r file; do


### PR DESCRIPTION
script has 2 infinite while loops and due to that container is not getting killed and waits for `terminationGracePeriodSeconds`. 
