### PR TITLE
Use better retention flags

### DIFF
--- a/base/prometheus/prometheus.yaml
+++ b/base/prometheus/prometheus.yaml
@@ -139,9 +139,9 @@ spec:
             - name: PROMETHEUS_URL
               value: "https://prometheus.base.example.com"
             - name: PROMETHEUS_DB_RETENTION
-              value: "30d"
+              value: "2d"
             - name: PROMETHEUS_DB_RETENTION_SIZE
-              value: "180GB" # Set to 90% size of the disk
+              value: "0" # Disabled by default
           image: prometheus
           livenessProbe:
             failureThreshold: 3


### PR DESCRIPTION
This allows us to overwrite retention size while being backward
compatible, allowing us to roll out this change much easier / safer.
