### PR TITLE
Revert "Downgrade Query to 0.34 (#104)"

### DIFF
--- a/base/thanos-query/kustomization.yaml
+++ b/base/thanos-query/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 images:
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.34.1
+    newTag: v0.35.1
 labels:
   - includeSelectors: true
     pairs:


### PR DESCRIPTION
This reverts commit 3e5b0349ae9b3963d6f2c628d978d2c7b61053af. Thanos rule now uses grpc endpoint for query.