### PR TITLE
Tune memcached and enable lazy index-header

### DIFF
--- a/base/thanos-store/memcached.yaml
+++ b/base/thanos-store/memcached.yaml
@@ -124,7 +124,7 @@ spec:
               type: RuntimeDefault
           args:
             - -m
-            - "9216"
+            - "8192"
             - --memory-file=/cache-state/memory_file
           ports:
             - name: memcache

--- a/base/thanos-store/thanos-store.yaml
+++ b/base/thanos-store/thanos-store.yaml
@@ -56,7 +56,7 @@ spec:
             - |-
               --index-cache.config="config":
                 "addresses":
-                - "dnssrv+_memcache._tcp.$(MEMCACHED_SVC)"
+                - "dnssrvnoa+_memcache._tcp.$(MEMCACHED_SVC)"
                 "dns_provider_update_interval": "10s"
                 "max_async_buffer_size": 100000
                 "max_async_concurrency": 100
@@ -73,7 +73,7 @@ spec:
               "chunk_subrange_ttl": "24h"
               "config":
                 "addresses":
-                - "dnssrv+_memcache._tcp.$(MEMCACHED_SVC)"
+                - "dnssrvnoa+_memcache._tcp.$(MEMCACHED_SVC)"
                 "dns_provider_update_interval": "10s"
                 "max_async_buffer_size": 100000
                 "max_async_concurrency": 100
@@ -88,6 +88,10 @@ spec:
               "metafile_exists_ttl": "2h"
               "metafile_max_size": "1MiB"
               "type": "memcached"
+            - --store.enable-index-header-lazy-reader
+            - --store.enable-lazy-expanded-postings
+            - --store.index-header-lazy-download-strategy=lazy
+            - --enable-auto-gomemlimit
             - --tracing.config-file=/etc/thanos-tracing/config.yaml
           env:
             - name: POD_NAMESPACE


### PR DESCRIPTION
Memcached is sized at 9216MiB, which is exactly 90% of the 10Gi PVC
and sits on the VolumeDiskUsage alert threshold, so a fully warm cache
would page the on-call. This caps it at 8192MiB (80%) so a full cache
stays under the alert.

Also moves memcached discovery to dnssrvnoa+ to keep jump-hash
sharding stable as pods are added or removed, and enables the lazy
index-header reader, lazy expanded postings, lazy download strategy,
and auto gomemlimit to cut RSS and startup cost.