### PR TITLE
Upgrade thanos to v0.42.4, prometheus to v3.13.2

### DIFF
--- a/base/prometheus/kustomization.yaml
+++ b/base/prometheus/kustomization.yaml
@@ -5,10 +5,10 @@ resources:
 images:
   - name: prometheus
     newName: prom/prometheus
-    newTag: v3.11.3
+    newTag: v3.13.2
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.41.0
+    newTag: v0.42.4
 labels:
   - includeSelectors: true
     pairs:

--- a/base/prometheus/prometheus.yaml
+++ b/base/prometheus/prometheus.yaml
@@ -102,6 +102,7 @@ spec:
             - --reloader.config-envsubst-file=/etc/prometheus-shared/prometheus.yaml
             - --reloader.config-file=/etc/prometheus/prometheus.yaml.tmpl
             - --tsdb.path=/prometheus/data
+            - --enable-auto-gomemlimit
           startupProbe:
             exec:
               command:

--- a/base/thanos-compact/kustomization.yaml
+++ b/base/thanos-compact/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 images:
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.41.0
+    newTag: v0.42.4
 labels:
   - includeSelectors: true
     pairs:

--- a/base/thanos-compact/thanos-compact.yaml
+++ b/base/thanos-compact/thanos-compact.yaml
@@ -60,6 +60,7 @@ spec:
             - --retention.resolution-raw=1y
             - --wait
             - --wait-interval=1h
+            - --enable-auto-gomemlimit
           ports:
             - name: http
               containerPort: 10902

--- a/base/thanos-query/kustomization.yaml
+++ b/base/thanos-query/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 images:
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.41.0
+    newTag: v0.42.4
 labels:
   - includeSelectors: true
     pairs:

--- a/base/thanos-query/thanos-query.yaml
+++ b/base/thanos-query/thanos-query.yaml
@@ -58,7 +58,8 @@ spec:
             - --query.replica-label=replica
             - --query.replica-label=rule_replica
             - --store.response-timeout=15s
-            - --store.sd-files=/etc/thanos/store-sd.yaml
+            - --endpoint.sd-config-file=/etc/thanos/store-sd.yaml
+            - --enable-auto-gomemlimit
             - --tracing.config-file=/etc/thanos-tracing/config.yaml
           env:
             - name: POD_NAMESPACE

--- a/base/thanos-receive/kustomization.yaml
+++ b/base/thanos-receive/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 images:
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.41.0
+    newTag: v0.42.4
 labels:
   - includeSelectors: true
     pairs:

--- a/base/thanos-receive/thanos-receive.yaml
+++ b/base/thanos-receive/thanos-receive.yaml
@@ -55,6 +55,7 @@ spec:
             - --tsdb.path=/var/thanos/receive
             - --label=receive_replica="$(NAME)"
             - --objstore.config-file=/etc/thanos/config.yaml
+            - --enable-auto-gomemlimit
           ports:
             - name: http
               containerPort: 10902

--- a/base/thanos-rule/kustomization.yaml
+++ b/base/thanos-rule/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 images:
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.41.0
+    newTag: v0.42.4
 labels:
   - includeSelectors: true
     pairs:

--- a/base/thanos-rule/thanos-rule.yaml
+++ b/base/thanos-rule/thanos-rule.yaml
@@ -71,6 +71,7 @@ spec:
             - --label=rule_replica="$(POD_NAME)"
             - --label=uw_environment="$(UW_ENVIROMENT)"
             - --objstore.config-file=/etc/thanos/config.yaml
+            - --enable-auto-gomemlimit
             - --tracing.config-file=/etc/thanos-tracing/config.yaml
           env:
             - name: ALERTMANAGER_URL

--- a/base/thanos-store/kustomization.yaml
+++ b/base/thanos-store/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 images:
   - name: thanos
     newName: quay.io/thanos/thanos
-    newTag: v0.41.0
+    newTag: v0.42.4
 labels:
   - includeSelectors: true
     pairs:

--- a/example/aws/kustomization.yaml
+++ b/example/aws/kustomization.yaml
@@ -1,22 +1,21 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
   - ../../base/
 #  - github.com/utilitywarehouse/thanos-manifests/base
 
   # Optional, only required to enable remote-write
   - ../../base/thanos-receive
 #  - github.com/utilitywarehouse/thanos-manifests/base/thanos-receive
-resources:
   - prometheus-ingress.yaml
   - thanos-query-ingress.yaml
   - thanos-rule-ingress.yaml
-patchesStrategicMerge:
-  - prometheus.yaml
-  - thanos-compact.yaml
-  - thanos-receive.yaml # Optional, only required to enable remote-write
-  - thanos-rule.yaml
-  - thanos-store.yaml
+patches:
+  - path: prometheus.yaml
+  - path: thanos-compact.yaml
+  - path: thanos-receive.yaml # Optional, only required to enable remote-write
+  - path: thanos-rule.yaml
+  - path: thanos-store.yaml
 configMapGenerator:
   # description: application alerts handled by thanos-rule
   # used-by: Thanos Rule

--- a/example/aws/resources/store-sd.yaml
+++ b/example/aws/resources/store-sd.yaml
@@ -1,12 +1,12 @@
 # Store targets for thanos-query to use for searching
-- targets:
+endpoints:
   # Prometheus sidecars for the short term metrics
-  - prometheus-0.thanos-sidecar:10901
-  - prometheus-1.thanos-sidecar:10901
+  - address: prometheus-0.thanos-sidecar:10901
+  - address: prometheus-1.thanos-sidecar:10901
   # Thanos Receive store gateway for short term metrics
-  - thanos-receive:10901
+  - address: thanos-receive:10901
   # Store gateway for long term metrics
-  - thanos-store:10901
+  - address: thanos-store:10901
   # Thanos ruler exposes synthetic time series of the form
   # ```
   # ALERTS{alertname="<alert name>", alertstate="pending|firing", <additional # alert labels>}
@@ -14,9 +14,8 @@
   # The sample value is set to 1 as long as the alert is in the indicated
   # active (pending or firing) state, and the series is marked stale when this is
   # no longer the case.
-  - thanos-rule:10901
-# Another instance of Prometheus/Thanos to be included in the queries
-- targets:
-  - prometheus-0.thanos-sidecar.example-namespace:10901
-  - prometheus-1.thanos-sidecar.example-namespace:10901
-  - thanos-store.example-namespace:10901
+  - address: thanos-rule:10901
+  # Another instance of Prometheus/Thanos to be included in the queries
+  - address: prometheus-0.thanos-sidecar.example-namespace:10901
+  - address: prometheus-1.thanos-sidecar.example-namespace:10901
+  - address: thanos-store.example-namespace:10901

--- a/example/aws/thanos-rule.yaml
+++ b/example/aws/thanos-rule.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: thanos-rule
 spec:

--- a/example/gcp/kustomization.yaml
+++ b/example/gcp/kustomization.yaml
@@ -1,16 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
   - ../../base/
 #  - github.com/utilitywarehouse/thanos-manifests/base
-resources:
   - prometheus-ingress.yaml
   - thanos-query-ingress.yaml
   - thanos-rule-ingress.yaml
-patchesStrategicMerge:
-  - gcp-credentials-patch.yaml
-  - prometheus.yaml
-  - thanos-rule.yaml
+patches:
+  - path: gcp-credentials-patch.yaml
+  - path: prometheus.yaml
+  - path: thanos-rule.yaml
 secretGenerator:
   # description: credentials for access to object storage
   # used-by: Prometheus, Thanos Store, Thanos Compact

--- a/example/gcp/resources/store-sd.yaml
+++ b/example/gcp/resources/store-sd.yaml
@@ -1,10 +1,10 @@
 # Store targets for thanos-query to use for searching
-- targets:
+endpoints:
   # Prometheus sidecars for the short term metrics
-  - prometheus-0.thanos-sidecar:10901
-  - prometheus-1.thanos-sidecar:10901
+  - address: prometheus-0.thanos-sidecar:10901
+  - address: prometheus-1.thanos-sidecar:10901
   # Store gateway for long term metrics
-  - thanos-store:10901
+  - address: thanos-store:10901
   # Thanos ruler exposes synthetic time series of the form
   # ```
   # ALERTS{alertname="<alert name>", alertstate="pending|firing", <additional # alert labels>}
@@ -12,9 +12,8 @@
   # The sample value is set to 1 as long as the alert is in the indicated
   # active (pending or firing) state, and the series is marked stale when this is
   # no longer the case.
-  - thanos-rule:10901
-# Another instance of Prometheus/Thanos to be included in the queries
-- targets:
-  - prometheus-0.thanos-sidecar.example-namespace:10901
-  - prometheus-1.thanos-sidecar.example-namespace:10901
-  - thanos-store.example-namespace:10901
+  - address: thanos-rule:10901
+  # Another instance of Prometheus/Thanos to be included in the queries
+  - address: prometheus-0.thanos-sidecar.example-namespace:10901
+  - address: prometheus-1.thanos-sidecar.example-namespace:10901
+  - address: thanos-store.example-namespace:10901

--- a/example/gcp/thanos-rule.yaml
+++ b/example/gcp/thanos-rule.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: thanos-rule
 spec:


### PR DESCRIPTION
# Upgrade thanos to v0.42.4, prometheus to v3.13.2

Upgrade all thanos components to v0.42.4 and prometheus to v3.13.2
(LTS), and add `--enable-auto-gomemlimit` to query, rule, compact,
receive and sidecar (store already had it).

## Changes
- thanos: v0.41.0 -> v0.42.4 (all 6 sub-bases)
- prometheus: v3.11.3 -> v3.13.2
- add `--enable-auto-gomemlimit` to thanos-query, thanos-rule,
  thanos-compact, thanos-receive and the sidecar
- migrate deprecated `--store.sd-files` to `--endpoint.sd-config-file`
- fix example overlays: thanos-rule patch used Deployment but base
  defines a StatefulSet
- convert example store-sd.yaml files to the new `endpoints:` format

## Breaking change for consumers

`--store.sd-files` was deprecated in thanos and replaced by
`--endpoint.sd-config-file`. The config file format changed:

- before (Prometheus file_sd): a YAML list of `- targets:` groups
  (with optional `labels:`)
- after: a YAML dict with an `endpoints:` list of `- address:`

The old `labels:` groups were not used by thanos-query (only the
target addresses were read), so no behavior is lost.

## Required follow-up for consumers

Consumers of this base must convert their store-sd config files to the
new `endpoints:` format. Do the config conversion in the SAME commit
as bumping the base ref, otherwise thanos-query fails to start (yaml
unmarshal error on the old list format).

Consumers that reference the base by a pinned SHA are unaffected until
they bump their ref. Consumers referencing `master` pick up this
change immediately on merge and must be converted first.