### PR TITLE
Set store index-header idle-timeout to 1m

### DIFF
--- a/base/thanos-store/thanos-store.yaml
+++ b/base/thanos-store/thanos-store.yaml
@@ -89,6 +89,7 @@ spec:
               "metafile_max_size": "1MiB"
               "type": "memcached"
             - --store.enable-index-header-lazy-reader
+            - --store.index-header-lazy-reader-idle-timeout=1m
             - --store.enable-lazy-expanded-postings
             - --store.index-header-lazy-download-strategy=lazy
             - --enable-auto-gomemlimit


### PR DESCRIPTION
The default 5m idle timeout keeps every index-header mmap'd for any block touched within a 5-minute query window. On stores with many blocks under continuous query load (e.g. dev-aws sys-prom, 2113 blocks) the resident set grows past the memory limit and the store thrashes in page-cache reclaim, causing S3/memcached/health timeouts and dropping old data from queries.

Verified on dev-aws: with idle-timeout=1m the store's memory stays bounded under wide-range query load (peaks ~800MB, releases back to ~240MB after idle) and 7-day queries return full data.