### PR TITLE
Revert lazy index-header and auto-gomemlimit

### DIFF
--- a/base/prometheus/prometheus.yaml
+++ b/base/prometheus/prometheus.yaml
@@ -102,7 +102,6 @@ spec:
             - --reloader.config-envsubst-file=/etc/prometheus-shared/prometheus.yaml
             - --reloader.config-file=/etc/prometheus/prometheus.yaml.tmpl
             - --tsdb.path=/prometheus/data
-            - --enable-auto-gomemlimit
           startupProbe:
             exec:
               command:

--- a/base/thanos-compact/thanos-compact.yaml
+++ b/base/thanos-compact/thanos-compact.yaml
@@ -60,7 +60,6 @@ spec:
             - --retention.resolution-raw=1y
             - --wait
             - --wait-interval=1h
-            - --enable-auto-gomemlimit
           ports:
             - name: http
               containerPort: 10902

--- a/base/thanos-query/thanos-query.yaml
+++ b/base/thanos-query/thanos-query.yaml
@@ -59,7 +59,6 @@ spec:
             - --query.replica-label=rule_replica
             - --store.response-timeout=15s
             - --endpoint.sd-config-file=/etc/thanos/store-sd.yaml
-            - --enable-auto-gomemlimit
             - --tracing.config-file=/etc/thanos-tracing/config.yaml
           env:
             - name: POD_NAMESPACE

--- a/base/thanos-receive/thanos-receive.yaml
+++ b/base/thanos-receive/thanos-receive.yaml
@@ -55,7 +55,6 @@ spec:
             - --tsdb.path=/var/thanos/receive
             - --label=receive_replica="$(NAME)"
             - --objstore.config-file=/etc/thanos/config.yaml
-            - --enable-auto-gomemlimit
           ports:
             - name: http
               containerPort: 10902

--- a/base/thanos-rule/thanos-rule.yaml
+++ b/base/thanos-rule/thanos-rule.yaml
@@ -71,7 +71,6 @@ spec:
             - --label=rule_replica="$(POD_NAME)"
             - --label=uw_environment="$(UW_ENVIROMENT)"
             - --objstore.config-file=/etc/thanos/config.yaml
-            - --enable-auto-gomemlimit
             - --tracing.config-file=/etc/thanos-tracing/config.yaml
           env:
             - name: ALERTMANAGER_URL

--- a/base/thanos-store/thanos-store.yaml
+++ b/base/thanos-store/thanos-store.yaml
@@ -88,11 +88,6 @@ spec:
               "metafile_exists_ttl": "2h"
               "metafile_max_size": "1MiB"
               "type": "memcached"
-            - --store.enable-index-header-lazy-reader
-            - --store.index-header-lazy-reader-idle-timeout=1m
-            - --store.enable-lazy-expanded-postings
-            - --store.index-header-lazy-download-strategy=lazy
-            - --enable-auto-gomemlimit
             - --tracing.config-file=/etc/thanos-tracing/config.yaml
           env:
             - name: POD_NAMESPACE


### PR DESCRIPTION
Lazy index-header download strategy caused query-time S3 index-header fetches that timed out on dev-aws, leaving the store unable to serve old blocks. auto-gomemlimit only constrains the Go heap, which is a small fraction of store RSS (dominated by mmap'd index headers), so it never helped memory and muddied diagnostics.

Restore the upstream defaults: eager index-header loading on store, and remove auto-gomemlimit from all thanos components.